### PR TITLE
Fixing unsupported operand types error when running on python3

### DIFF
--- a/relisterine.py
+++ b/relisterine.py
@@ -116,7 +116,7 @@ def main():
 
     renew_links = check_for_renewals()
     if len(renew_links):  # renew links are present
-        print(bright_green + "%d listings eligible for renewal have been found!") % len(renew_links)
+        print((bright_green + "%d listings eligible for renewal have been found!") % len(renew_links))
         click_renew_links(renew_links)
     else:  # no renewal links at this time
         print(bright_yellow + "No listings to renew.  Exiting!")


### PR DESCRIPTION
The code you have runs perfectly for me on python3 except for line 119 of relisterine.py where:
 
`print(bright_green + "%d listings eligible for renewal have been found!") % len(renew_links)`

I get this error:

`TypeError: unsupported operand type(s) for %: 'NoneType' and 'int'`

Per [this](https://stackoverflow.com/questions/22070888/typeerror-unsupported-operand-types-for-nonetype-and-int) stackoverflow post, this can be resolved by:

`print((bright_green + "%d listings eligible for renewal have been found!") % len(renew_links))`

I've tested this on python3 and it works. I have not tested this change on python2
